### PR TITLE
Distinguish the models used in the executor and evaluator

### DIFF
--- a/sdk/utils.py
+++ b/sdk/utils.py
@@ -37,6 +37,17 @@ def set_llm_endpoint_from_config(config_path):
     llm_config = config.get('llm', {})
     evaluator_config = config.get('evaluator_api_keys', {})
 
+    # Validate evaluator_api_keys: if the section exists, all keys must have non-empty values
+    if evaluator_config:
+        empty_keys = [key for key, value in evaluator_config.items() if not value or str(value).strip() == '']
+        if empty_keys:
+            logger.error('Error: The following required API keys in [evaluator_api_keys] are empty:')
+            for key in empty_keys:
+                logger.error('  - %s', key)
+            logger.error('[evaluator_api_keys] section indicates these are REQUIRED for the benchmark to run.')
+            logger.error('Please provide valid API keys for all entries in [evaluator_api_keys].')
+            sys.exit(1)
+
     # Detect conflicts between [llm] and [evaluator_api_keys]
     common_keys = set(llm_config.keys()) & set(evaluator_config.keys())
     if common_keys:


### PR DESCRIPTION
## Summary

  This PR addresses issue #1 by extending the `env.toml` format to distinguish between:
  - **Evaluator API keys**: Required for the evaluation workflow (e.g., LLM judges)
  - **Model under test API keys**: Optional, for the models being evaluated

  ## Problem

  Previously, all API keys were mixed in the `[llm]` section. Users couldn't tell:
  - Which API keys are **required** for the benchmark to run
  - Which API keys are **optional** depending on which model they want to test
  - When multiple benchmarks coexist, which API keys are mandatory

  ## Solution

  - Add support for [evaluator_api_keys] section in env.toml  
  - Validate that all keys in [evaluator_api_keys] have non-empty values
  - Maintain backward compatibility with existing [llm] section
  - Detect and warn about conflicting API keys between sections

  ### New `env.toml` Format

  Benchmarks can now use an optional `[evaluator_api_keys]` section:

  ```toml
  #sysmobench
  # ===== Evaluator API Keys (Required) =====
  # API keys needed for the evaluation workflow
  [evaluator_api_keys]
  ANTHROPIC_API_KEY = "xxx"

  # ===== Model Under Test API Keys (Optional) =====
  # API keys for models you want to test
  [llm]
  OPENAI_API_KEY = "xxx"
  AZURE_API_KEY = "xxx"
  ANTHROPIC_API_KEY = "xxx"