### PR TITLE
`courseexam`: Add Experimental Validation Workflow

### DIFF
--- a/.github/workflows/validate-exam-pr.yml
+++ b/.github/workflows/validate-exam-pr.yml
@@ -101,7 +101,7 @@ jobs:
           **Exams tested:**
           $(echo "${{ steps.detect_exams.outputs.exam_ids }}" | tr ',' '\n' | sed 's/^/- `/' | sed 's/$/`/')
 
-          **Evaluation file:** Download the \`evaluation-results\` artifact from [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and inspect it using \`inspect view <file>.eval\` or the [Inspect VS Code extension](https://marketplace.visualstudio.com/items?itemName=UKGovernmentAISafetyInstitute.inspect-ai).
+          **Evaluation file:** Download the \`evaluation-results\` artifact from [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) and inspect it using \`inspect view <file>.eval\` or the [Inspect VS Code extension](https://marketplace.visualstudio.com/items?itemName=UKGovernmentAISafetyInstitute.inspect-ai). For more details on how to use the web-based log viewer, see [Inspect Log Viewer documentation](https://inspect.aisi.org.uk/log-viewer.html)
 
           This experimental run helps you verify that questions have enough context for the LLM to answer and that grading rubrics are appropriate.
           EOF


### PR DESCRIPTION
## Description

As discussed, this PR adds a ci workflow to run experimental evaluations on new exam submissions to help contributors validate their exams before merging.


It's triggered manually with workflow dispatch on PRs targeting main

It detects new/modified exams and runs evaluation using `anthropic/claude-haiku-4-5` for both testing and LLM-as-judge then adds  comment on the PR with results and instructions to inspect the full results


I tested this workflow on a private repository

